### PR TITLE
Fix namespace stuff

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -8,7 +8,7 @@ open NuGetHelper
 open RestorePackageHelper
 open FSharpUtils.Fake.Config
 
-DatNET.Targets.Initialize id
+datNET.Targets.Initialize id
 
 Target "RestorePackages" (fun _ ->
   Source.SolutionFile

--- a/fake.bat
+++ b/fake.bat
@@ -3,7 +3,7 @@
 set fake_args=%*
 
 cd "._fake"
-call "paket.bat" "restore"
+call "paket.bat" "install"
 cd ".."
 
 "._fake\packages\FAKE\tools\FAKE.exe" "build.fsx" %fake_args%


### PR DESCRIPTION
Also, fake.bat should call paket install instead of paket restore for cases in which a paket.lock file doesn't exist yet.
